### PR TITLE
fix: Replace silent errors with proper logging and notifications (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Users can safely share logs in GitHub issues without exposing app usage
 
 ### Fixed
+- **Error logging for snapshot operations** (#29)
+  - Replaced silent try? with do-catch blocks in ManualSnapshotStorage
+  - Save/load errors now output to debug log with error details
+  - Save failure triggers user notification for visibility
 - **Crash prevention in Accessibility API calls** (#27)
   - Added nil checks before force casting AXUIElement and AXValue types
   - Validates API success status before accessing return values


### PR DESCRIPTION
- Replace try? with do-catch in ManualSnapshotStorage.save() and load()
- Add debugPrint for encode/decode errors with error details
- Add user notification on snapshot save failure
- Unify print() to debugPrint() for consistent logging
- Add UserNotifications import